### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/sjharperengineering/2217349d-1239-48fb-bf9c-e0e95a61a35d/ed621d24-3677-402e-b541-05616a4bf888/_apis/work/boardbadge/28f9ada5-6341-45fd-acd4-0b74e3ac140f)](https://dev.azure.com/sjharperengineering/2217349d-1239-48fb-bf9c-e0e95a61a35d/_boards/board/t/ed621d24-3677-402e-b541-05616a4bf888/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#7](https://dev.azure.com/sjharperengineering/2217349d-1239-48fb-bf9c-e0e95a61a35d/_workitems/edit/7). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.